### PR TITLE
autoruns: Removes /accepteula arg (no longer needed/usable)

### DIFF
--- a/bucket/autoruns.json
+++ b/bucket/autoruns.json
@@ -23,8 +23,7 @@
             "shortcuts": [
                 [
                     "Autoruns64.exe",
-                    "SysInternals/Autoruns",
-                    "/accepteula"
+                    "SysInternals/Autoruns"
                 ]
             ]
         },
@@ -36,8 +35,7 @@
             "shortcuts": [
                 [
                     "Autoruns.exe",
-                    "SysInternals/Autoruns",
-                    "/accepteula"
+                    "SysInternals/Autoruns"
                 ]
             ]
         },
@@ -55,8 +53,7 @@
             "shortcuts": [
                 [
                     "Autoruns64a.exe",
-                    "SysInternals/Autoruns",
-                    "/accepteula"
+                    "SysInternals/Autoruns"
                 ]
             ]
         }


### PR DESCRIPTION
- Closes #2

Seems like new versions don't have an EULA upon first startup, and that's why it shows a usage window describing the arguments that are currently usable; /accepteula not being one of them.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
